### PR TITLE
在xposed插件中andserver2.0无法初始化

### DIFF
--- a/api/src/main/java/com/yanzhenjie/andserver/AndServer.java
+++ b/api/src/main/java/com/yanzhenjie/andserver/AndServer.java
@@ -33,7 +33,7 @@ public class AndServer {
     private static Context sContext;
     private static boolean sDebug;
 
-    static void initialize(@NonNull Context context) {
+    public static void initialize(@NonNull Context context) {
         Assert.notNull(context, "The context must not be null.");
 
         if (sContext == null) {


### PR DESCRIPTION
你好，我正在xposed插件中集成andserver，但是升级到2.0之后发现andserver无法初始化
这个是我启动serever的代码
```
XposedHelpers.findAndHookMethod(MainActivity, "onCreate", Bundle.class, new XC_MethodHook() {
            @Override
            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
                super.beforeHookedMethod(param);
            }

            @Override
            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                super.afterHookedMethod(param);
                //这里执行启动server，但是服务器没有成功启动
                WebServer.startServer();
            }
        });
```

经过调试发现是因为在xposed插件中ContentProvider没有初始化
https://github.com/yanzhenjie/AndServer/blob/94bdbfe4258b9acf0f53b2ef6659263edd51929f/api/src/main/java/com/yanzhenjie/andserver/Initialization.java#L32

所以是否可以考虑将AndServer.initialize公开出来手动传入context初始化一下？